### PR TITLE
Update __isset to check for method on Presenter

### DIFF
--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -87,7 +87,7 @@ abstract class BasePresenter
     }
 
     /**
-     * Is the key set on the wrapped object?
+     * Is the key set on either the presenter or the wrapped object?
      *
      * @param string $key
      *
@@ -95,6 +95,9 @@ abstract class BasePresenter
      */
     public function __isset($key)
     {
+        if (method_exists($this, $key)) {
+            return true;
+        }
         return isset($this->wrappedObject->$key);
     }
 

--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -98,6 +98,7 @@ abstract class BasePresenter
         if (method_exists($this, $key)) {
             return true;
         }
+        
         return isset($this->wrappedObject->$key);
     }
 

--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -98,7 +98,7 @@ abstract class BasePresenter
         if (method_exists($this, $key)) {
             return true;
         }
-        
+
         return isset($this->wrappedObject->$key);
     }
 

--- a/tests/BasePresenterTest.php
+++ b/tests/BasePresenterTest.php
@@ -77,6 +77,7 @@ class BasePresenterTest extends AbstractTestCase
     {
         $presenter = new DecoratedAtomPresenter($this->decoratedAtom);
         $this->assertTrue(isset($presenter->myProperty));
+        $this->assertTrue(isset($presenter->favoriteMovie));
     }
 
     public function testToString()


### PR DESCRIPTION
Functions like `lists()` on Laravel Collections uses `isset()` to
determine whether an object has a particular key. It is useful (for
example in HTML select boxes) to be able to specify a key that is not present on
the underlying object, as it is purely for presentation purposes.

Currently this is not possible, as the `__isset` call will return false
unless the specified key exists on the `wrappedObject`, even though a
corresponding method may exist on the Presenter.

This change adds a check for the method name on the Presenter, before
checking the `wrappedObject`