### PR TITLE
let presenter decorators be aware of "themselves"

### DIFF
--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -60,7 +60,7 @@ abstract class BasePresenter
     public function __get($key)
     {
         if (method_exists($this, $key)) {
-            return $this->{$key}();
+            return $this->{$key}($this->wrappedObject->$key);
         }
 
         return $this->wrappedObject->$key;


### PR DESCRIPTION
I really like this presenter package but for one thing. It seems silly that the decorators don't know about their model attribute counterparts. For example:

```php
public function published_at()
{
     $published = $this->wrappedObject->published_at;

     return Carbon::createFromFormat('Y-m-d H:i:s', $published)
         ->toFormattedDateString();
}
```
should/could be:
```php
public function published_at($self)
{
     return $self->format('n/j/Y');
}
```
this assumes that in the model `protected $dates = ['published_at'];` has been set.
I propose that the decorators become self aware.